### PR TITLE
Added derive-macro argument parsing and changed fields structure

### DIFF
--- a/BCMMacros/DeriveMacros.ml
+++ b/BCMMacros/DeriveMacros.ml
@@ -28,10 +28,17 @@ type ctype =
   | Union of ident option * (ctype * ident) list
   | Enum of ident option * ident list
 
+
+type field =
+  { name : ident
+  ; ctype : ctype
+  ; attributes : (ident * macro_token option) list
+  }
+
 type cstruct =
   { name : ident
   (* TODO: Add support for anonymous structs and unions *)
-  ; fields : (ctype * ident) list
+  ; fields : field list
   ; typedef: ident option
   }
 

--- a/CProcessing/PPCast.ml
+++ b/CProcessing/PPCast.ml
@@ -87,10 +87,15 @@ let pp_basic_type fmt = function
 let rec pp_cstruct fmt {name; fields; typedef} =
   Format.fprintf fmt "{%a; %a; %a}"
   Format.pp_print_string name
-  (Format.pp_print_list (fun fmt (ctype, name) ->
-    Format.fprintf fmt "{%a, %a}"
+  (Format.pp_print_list (fun fmt {name; ctype; attributes} ->
+    Format.fprintf fmt "{%a, %a, %a}"
     pp_ctype ctype
     Format.pp_print_string name
+    (Format.pp_print_list (fun fmt (id, tokens) ->
+      Format.fprintf fmt "(%a, %a)"
+      Format.pp_print_string id
+      (Format.pp_print_option pp_macro_token) tokens
+    )) attributes
   )) fields
   (Format.pp_print_option Format.pp_print_string) typedef
 and pp_ctype fmt = function

--- a/CProcessing/Print.ml
+++ b/CProcessing/Print.ml
@@ -86,7 +86,7 @@ and print_fields = function
 
 let string_of_struct cstruct =
   let name = cstruct.name
-  in let fields = cstruct.fields
+  in let fields = cstruct.fields |> List.map (fun {name; ctype; _} -> (ctype, name))
   in let (td_pref, td_suf) = match cstruct.typedef with
     | Some id -> "typedef ", " " ^ id
     | None -> "", ""

--- a/CProcessing/cLexer.mll
+++ b/CProcessing/cLexer.mll
@@ -74,6 +74,7 @@ read = parse
   | "!" { NOT }
 
   | "=" { ASSIGN }
+  | "->" { ARROW }
  
   | "<<=" { SH_LEFT_ASSIGN }
   | "<<" { SH_LEFT }

--- a/MacroGenerator/Transform.ml
+++ b/MacroGenerator/Transform.ml
@@ -60,8 +60,8 @@ let transform_file include_paths env cfile =
       in tokens ^ aux_transform_file env rest
     
     | Derive (interfaces, cstruct) :: rest ->
-      generate_interface_implementations env interfaces cstruct
-      ^ Print.string_of_struct cstruct
+      Print.string_of_struct cstruct
+      ^ generate_interface_implementations env interfaces cstruct
       ^ aux_transform_file env rest
 
     | [] -> "\n"

--- a/test_bcm/ParseDeriveMacro/attributes.c
+++ b/test_bcm/ParseDeriveMacro/attributes.c
@@ -1,0 +1,11 @@
+#derive(attr)
+struct Art {
+    #[]
+    int n;
+
+    #[string, str_len]
+    char *str;
+
+    #[len(n), display_name("ArrAy")]
+    unsigned long long array[0];
+};

--- a/test_bcm/ParseDeriveMacro/test_ParseDeriveMacro.ml
+++ b/test_bcm/ParseDeriveMacro/test_ParseDeriveMacro.ml
@@ -38,11 +38,21 @@ let basic_fields = (root_dir ^ "basic_fields.c", [
   Derive (["ser1al1ze"], {
     name = "test_1ng";
     fields = [
-      (Basic CInt, "a");
-      (Basic CFloat, "b");
-      (Basic CChar, "c");
-      (Basic CDouble, "d");
-      (Tdef "uint8_t", "e");
+      { name = "a"
+      ; ctype = Basic CInt
+      ; attributes = [] };
+      { name = "b"
+      ; ctype = Basic CFloat
+      ; attributes = [] };
+      { name = "c"
+      ; ctype = Basic CChar
+      ; attributes = [] };
+      { name = "d"
+      ; ctype = Basic CDouble
+      ; attributes = [] };
+      { name = "e"
+      ; ctype = Tdef "uint8_t"
+      ; attributes = [] };
     ];
     typedef = Some "test_1ng";
   });
@@ -53,10 +63,18 @@ let awful_field_types = (root_dir ^ "awful_field_types.c", [
   Derive (["ser1al1ze"], {
     name = "test_1ng";
     fields = [
-      (Basic CUInt, "a");
-      (Basic CUChar, "c");
-      (Basic CLongDouble, "d");
-      (Basic CULLong, "e");
+      { name = "a"
+      ; ctype = Basic CUInt
+      ; attributes = [] };
+      { name = "c"
+      ; ctype = Basic CUChar
+      ; attributes = [] };
+      { name = "d"
+      ; ctype = Basic CLongDouble
+      ; attributes = [] };
+      { name = "e"
+      ; ctype = Basic CULLong
+      ; attributes = [] };
     ];
     typedef = None;
   });
@@ -67,9 +85,15 @@ let parse_pointers = (root_dir ^ "pointers.c", [
   Derive (["deser"], {
     name = "This";
     fields = [
-      (Pointer (Basic CChar), "str");
-      (Pointer (Basic CInt), "a");
-      (Pointer (Basic CULLong), "e");
+      { name = "str"
+      ; ctype = Pointer (Basic CChar)
+      ; attributes = [] };
+      { name = "a"
+      ; ctype = Pointer (Basic CInt)
+      ; attributes = [] };
+      { name = "e"
+      ; ctype = Pointer (Basic CULLong)
+      ; attributes = [] };
     ];
     typedef = None;
   });
@@ -80,8 +104,12 @@ let parse_multi_pointer = (root_dir ^ "multi_pointer.c", [
   Derive (["deser"], {
     name = "This";
     fields = [
-      (Pointer (Pointer (Basic CInt)), "num");
-      (Pointer (Pointer (Pointer (Pointer (Basic CUShort)))), "horror");
+      { name = "num"
+      ; ctype = Pointer (Pointer (Basic CInt))
+      ; attributes = [] };
+      { name = "horror"
+      ; ctype = Pointer (Pointer (Pointer (Pointer (Basic CUShort))))
+      ; attributes = [] };
     ];
     typedef = None;
   });
@@ -92,9 +120,15 @@ let parse_array = (root_dir ^ "array.c", [
   Derive (["stuff"], {
     name = "stuff";
     fields = [
-      (Array (Basic CUInt, [10]), "a");
-      (Array (Pointer (Basic CChar), [0]), "b");
-      (Array (Basic CChar, [1; 2; 3]), "c");
+      { name = "a"
+      ; ctype = Array (Basic CUInt, [10])
+      ; attributes = [] };
+      { name = "b"
+      ; ctype = Array (Pointer (Basic CChar), [0])
+      ; attributes = [] };
+      { name = "c"
+      ; ctype = Array (Basic CChar, [1; 2; 3])
+      ; attributes = [] };
     ];
     typedef = Some "ABC";
   });
@@ -105,10 +139,35 @@ let parse_functions = (root_dir ^ "functions.c", [
   Derive (["stuff"], {
     name = "stuff";
     fields = [
-      (Function (Pointer (Basic CVoid), [Basic CInt; Pointer (Basic CUInt)]), "abc");
-      (Function (Basic CLLong, [Basic CVoid]), "side_effect")
+      { name = "abc"
+      ; ctype = Function (Pointer (Basic CVoid), [Basic CInt; Pointer (Basic CUInt)])
+      ; attributes = [] };
+      { name = "side_effect"
+      ; ctype = Function (Basic CLLong, [Basic CVoid])
+      ; attributes = [] };
     ];
     typedef = Some "ABC";
+  });
+  CCode ";"
+])
+
+let parse_attributes = (root_dir ^ "attributes.c", [
+  Derive (["attr"], {
+    name = "Art";
+    fields = [
+      { name = "n"
+      ; ctype = Basic CInt
+      ; attributes = [] };
+      { name = "str"
+      ; ctype = Pointer (Basic CChar)
+      ; attributes = [("string", None); ("str_len", None)] };
+      { name = "array"
+      ; ctype = Array (Basic CULLong, [0])
+      ; attributes = [
+        ("len", Some (Ident "n"));
+        ("display_name", Some (String "ArrAy"))]}
+    ];
+    typedef = None;
   });
   CCode ";"
 ])
@@ -135,4 +194,6 @@ let () =
       [ test_case "check if equal" `Quick (check_file_parsing "Parse array" parse_array); ];
     "Parse functions",
       [ test_case "check if equal" `Quick (check_file_parsing "Parse functions" parse_functions); ];
+    "Parse attributes",
+      [ test_case "check if equal" `Quick (check_file_parsing "Parse attributes" parse_attributes); ];
   ]

--- a/test_bcm/PrintStruct/test_PrintStruct.ml
+++ b/test_bcm/PrintStruct/test_PrintStruct.ml
@@ -13,7 +13,15 @@ let minimal_struct = (
 let basic_fields = (
     { name = "basic"
     ; fields = [
-      Basic CInt, "a"; Basic CULLong, "u_l_l"; Tdef "uint64_t", "u64"
+      { name = "a"
+      ; ctype = Basic CInt
+      ; attributes = []};
+      { name = "u_l_l"
+      ; ctype = Basic CULLong
+      ; attributes = []};
+      { name = "u64"
+      ; ctype = Tdef "uint64_t"
+      ; attributes = []}
     ]
     ; typedef = None
     },
@@ -23,7 +31,15 @@ let basic_fields = (
 let pointers = (
     { name = "pointers"
     ; fields = [
-      Pointer (Basic CInt), "a"; Pointer (Pointer (Basic CULLong)), "u_l_l"; Pointer (Tdef "uint64_t"), "u64"
+      { name = "a"
+      ; ctype = Pointer (Basic CInt)
+      ; attributes = []};
+      { name = "u_l_l"
+      ; ctype = Pointer (Pointer (Basic CULLong))
+      ; attributes = []};
+      { name = "u64"
+      ; ctype = Pointer (Tdef "uint64_t")
+      ; attributes = []}
     ]
     ; typedef = None
     },
@@ -33,7 +49,15 @@ let pointers = (
 let arrays = (
     { name = "arrays"
     ; fields = [
-      Array (Basic CInt, [5]), "a"; Array (Pointer (Basic CULLong), [5; 5]), "u_l_l"; Array (Tdef "uint64_t", [5]), "u64"]
+      { name = "a"
+      ; ctype = Array (Basic CInt, [5])
+      ; attributes = []};
+      { name = "u_l_l"
+      ; ctype = Array (Pointer (Basic CULLong), [5; 5])
+      ; attributes = []};
+      { name = "u64"
+      ; ctype = Array (Tdef "uint64_t", [5])
+      ; attributes = []}]
     ; typedef = None
     },
     "struct arrays { int a[5]; unsigned long long* u_l_l[5][5]; uint64_t u64[5];  }"
@@ -43,8 +67,12 @@ let arrays = (
 let functions = (
     { name = "functions"
     ; fields = [
-      Function (Basic CInt, [Basic CInt; Basic CInt]), "a";
-      Function (Pointer (Tdef "uint64_t"), []), "u64"
+      { name = "a"
+      ; ctype = Function (Basic CInt, [Basic CInt; Basic CInt])
+      ; attributes = []};
+      { name = "u64"
+      ; ctype = Function (Pointer (Tdef "uint64_t"), [])
+      ; attributes = []}
     ]
     ; typedef = None
     },
@@ -54,8 +82,12 @@ let functions = (
 let cstruct = (
     { name = "s"
     ; fields = [
-      Struct (Some "a", []), "s";
-      Struct (None, [Basic CInt, "num"; Basic CBool, "b"]), "s2";
+      { name = "s"
+      ; ctype = Struct (Some "a", [])
+      ; attributes = []};
+      { name = "s2"
+      ; ctype = Struct (None, [Basic CInt, "num"; Basic CBool, "b"])
+      ; attributes = []};
     ]
     ; typedef = Some "s_t"
     },
@@ -65,8 +97,12 @@ let cstruct = (
 let union = (
     { name = "u"
     ; fields = [
-      Union (Some "a", []), "u";
-      Union (None, [Basic CInt, "num"; Basic CBool, "b"]), "u2";
+      { name = "u"
+      ; ctype = Union (Some "a", [])
+      ; attributes = []};
+      { name = "u2"
+      ; ctype = Union (None, [Basic CInt, "num"; Basic CBool, "b"])
+      ; attributes = []};
     ]
     ; typedef = Some "u_t"
     },
@@ -76,8 +112,12 @@ let union = (
 let enum = (
     { name = "e"
     ; fields = [
-      Enum (Some "a", ["A"; "B"; "C"]), "e";
-      Enum (None, ["A"; "B"; "C"]), "e2";
+      { name = "e"
+      ; ctype = Enum (Some "a", ["A"; "B"; "C"])
+      ; attributes = []};
+      { name = "e2"
+      ; ctype = Enum (None, ["A"; "B"; "C"])
+      ; attributes = []};
     ]
     ; typedef = Some "e_t"
     },


### PR DESCRIPTION
Derive macros now accept lists of arguments attached to each struct field.